### PR TITLE
fix(build-url): pass optional gateway enpoint when build url

### DIFF
--- a/src/constants/api-endpoint.constant.ts
+++ b/src/constants/api-endpoint.constant.ts
@@ -1,5 +1,5 @@
 export const VNPAY_GATEWAY_SANDBOX_HOST = 'https://sandbox.vnpayment.vn';
 
-export const GATEWAY_ENDPOINT = 'paymentv2/vpcpay.html';
+export const PAYMENT_ENDPOINT = 'paymentv2/vpcpay.html';
 export const QUERY_DR_REFUND_ENDPOINT = 'merchant_webapi/api/transaction';
 export const GET_BANK_LIST_ENDPOINT = 'qrpayauth/api/merchant/get_bank_list';

--- a/src/types/vnpay-config.type.ts
+++ b/src/types/vnpay-config.type.ts
@@ -40,6 +40,14 @@ export type VNPayConfig = {
     api_Host?: string;
 
     /**
+     * Endpoint API của VNPay
+     * @en  Endpoint of VNPay
+     * @default 'paymentv2/vpcpay.html'
+     * @example 'paymentv2/vpcpay.html'
+     */
+    endPoint?: string;
+
+    /**
      * Chế độ test
      * @default false
      */

--- a/src/types/vnpay-config.type.ts
+++ b/src/types/vnpay-config.type.ts
@@ -40,12 +40,12 @@ export type VNPayConfig = {
     api_Host?: string;
 
     /**
-     * Endpoint API của VNPay
-     * @en  Endpoint of VNPay
+     * Payment endpoint API của VNPay
+     * @en  Payment endpoint of VNPay
      * @default 'paymentv2/vpcpay.html'
      * @example 'paymentv2/vpcpay.html'
      */
-    endPoint?: string;
+    paymentEndpoint?: string;
 
     /**
      * Chế độ test

--- a/src/vnpay.ts
+++ b/src/vnpay.ts
@@ -65,6 +65,7 @@ export class VNPay {
         vnp_CurrCode = VnpCurrCode.VND,
         vnp_Locale = VnpLocale.VN,
         testMode = false,
+        endPoint = GATEWAY_ENDPOINT,
         ...config
     }: VNPayConfig) {
         if (testMode) {
@@ -150,7 +151,7 @@ export class VNPay {
                 const redirectUrl = new URL(
                     resolveUrlString(
                         this.globalDefaultConfig.api_Host ?? VNPAY_GATEWAY_SANDBOX_HOST,
-                        GATEWAY_ENDPOINT,
+                        this.globalDefaultConfig.endPoint ?? GATEWAY_ENDPOINT,
                     ),
                 );
                 Object.entries(dataToBuild)

--- a/src/vnpay.ts
+++ b/src/vnpay.ts
@@ -1,7 +1,7 @@
 import timezone from 'moment-timezone';
 import {
     VNPAY_GATEWAY_SANDBOX_HOST,
-    GATEWAY_ENDPOINT,
+    PAYMENT_ENDPOINT,
     VNP_DEFAULT_COMMAND,
     VNP_VERSION,
     QUERY_DR_REFUND_ENDPOINT,
@@ -65,7 +65,7 @@ export class VNPay {
         vnp_CurrCode = VnpCurrCode.VND,
         vnp_Locale = VnpLocale.VN,
         testMode = false,
-        endPoint = GATEWAY_ENDPOINT,
+        paymentEndpoint = PAYMENT_ENDPOINT,
         ...config
     }: VNPayConfig) {
         if (testMode) {
@@ -151,7 +151,7 @@ export class VNPay {
                 const redirectUrl = new URL(
                     resolveUrlString(
                         this.globalDefaultConfig.api_Host ?? VNPAY_GATEWAY_SANDBOX_HOST,
-                        this.globalDefaultConfig.endPoint ?? GATEWAY_ENDPOINT,
+                        this.globalDefaultConfig.paymentEndpoint ?? PAYMENT_ENDPOINT,
                     ),
                 );
                 Object.entries(dataToBuild)


### PR DESCRIPTION
**Description
- I see that the gateway endpoint in production is different from the sandbox so I think it would be better if we could pass the endpoint to it

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Test
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR related issues or references:**
- 
