### PR TITLE
fix: 🐛 correct type for consoleLogger symbol parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vnpay",
-    "version": "2.4.3-rc.0",
+    "version": "2.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vnpay",
-            "version": "2.4.3-rc.0",
+            "version": "2.4.3",
             "license": "MIT",
             "dependencies": {
                 "dayjs": "^1.11.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vnpay",
-    "version": "2.4.2",
+    "version": "2.4.3-rc.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vnpay",
-            "version": "2.4.2",
+            "version": "2.4.3-rc.0",
             "license": "MIT",
             "dependencies": {
                 "dayjs": "^1.11.13"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "url": "git+https://github.com/lehuygiang28/vnpay.git"
     },
     "homepage": "https://vnpay.js.org",
-    "version": "2.4.3-rc.0",
+    "version": "2.4.3",
     "description": "An open-source nodejs library support to payment with VNPay",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "url": "git+https://github.com/lehuygiang28/vnpay.git"
     },
     "homepage": "https://vnpay.js.org",
-    "version": "2.4.2",
+    "version": "2.4.3-rc.0",
     "description": "An open-source nodejs library support to payment with VNPay",
     "type": "module",
     "main": "./dist/index.cjs",

--- a/scripts/fix-dayjs-imports.ts
+++ b/scripts/fix-dayjs-imports.ts
@@ -6,62 +6,129 @@ import { join, resolve } from 'path';
  * This addresses the ES module resolution issue where Node.js and bundlers
  * require explicit file extensions for imports.
  */
-export async function fixDayjsImports() {
+export async function fixDayjsImports(): Promise<number> {
     try {
+        // Validate dist directory exists
         const distDir = resolve('dist');
+
+        try {
+            await readdir(distDir);
+        } catch (error) {
+            console.warn('⚠️  dist directory not found, skipping dayjs import fix');
+            return 0;
+        }
+
         const files = await readdir(distDir);
 
+        // Edge case: empty dist directory
+        if (files.length === 0) {
+            console.log('ℹ️  No files found in dist directory');
+            return 0;
+        }
+
         let fixedFilesCount = 0;
+        let processedFiles = 0;
+        const errors: Array<{ file: string; error: Error }> = [];
 
         for (const file of files) {
-            // Only process .js files, skip source maps
-            if (!file.endsWith('.js') || file.endsWith('.map')) {
-                continue;
-            }
-
-            const filePath = join(distDir, file);
-
-            // Read file content once
-            const originalContent = await readFile(filePath, 'utf8');
-
-            // Create quote-agnostic regex patterns for both single and double quotes
-            const importPatterns = [
-                // from 'dayjs/plugin/timezone' or from "dayjs/plugin/timezone"
-                /from ['"](dayjs\/plugin\/(timezone|utc))['"]/g,
-                // import 'dayjs/plugin/timezone' or import "dayjs/plugin/timezone"
-                /import ['"](dayjs\/plugin\/(timezone|utc))['"]/g,
-            ];
-
-            // Apply all replacements
-            let modifiedContent = originalContent;
-            let hasChanges = false;
-
-            for (const pattern of importPatterns) {
-                const newContent = modifiedContent.replace(pattern, (match, pluginPath) => {
-                    hasChanges = true;
-                    return match.replace(pluginPath, `${pluginPath}.js`);
-                });
-
-                if (newContent !== modifiedContent) {
-                    modifiedContent = newContent;
+            try {
+                // Only process .js files, skip source maps and other non-JS files
+                if (!file.endsWith('.js') || file.endsWith('.map') || file.includes('.d.ts')) {
+                    continue;
                 }
-            }
 
-            // Only write if changes were made
-            if (hasChanges) {
-                await writeFile(filePath, modifiedContent, 'utf8');
-                console.log(`🔧 Fixed dayjs imports in ${file}`);
-                fixedFilesCount++;
+                const filePath = join(distDir, file);
+                processedFiles++;
+
+                // Read file content with error handling
+                let originalContent: string;
+                try {
+                    originalContent = await readFile(filePath, 'utf8');
+                } catch (error) {
+                    errors.push({ file, error: error as Error });
+                    console.warn(`⚠️  Failed to read file ${file}:`, (error as Error).message);
+                    continue;
+                }
+
+                // Edge case: empty file
+                if (originalContent.length === 0) {
+                    continue;
+                }
+
+                // Apply superior regex patterns with backreferences for quote consistency
+                let modifiedContent = originalContent;
+                let hasChanges = false;
+
+                // Pattern 1: from 'dayjs/plugin/timezone' or from "dayjs/plugin/timezone"
+                const fromPattern = /from (['"])dayjs\/plugin\/(timezone|utc)\1/g;
+                const fromMatches = modifiedContent.match(fromPattern);
+                if (fromMatches) {
+                    modifiedContent = modifiedContent.replace(
+                        fromPattern,
+                        (_match, quote: string, plugin: string) => {
+                            hasChanges = true;
+                            return `from ${quote}dayjs/plugin/${plugin}.js${quote}`;
+                        },
+                    );
+                }
+
+                // Pattern 2: import 'dayjs/plugin/timezone' or import "dayjs/plugin/timezone"
+                const importPattern = /import (['"])dayjs\/plugin\/(timezone|utc)\1/g;
+                const importMatches = modifiedContent.match(importPattern);
+                if (importMatches) {
+                    modifiedContent = modifiedContent.replace(
+                        importPattern,
+                        (_match, quote: string, plugin: string) => {
+                            hasChanges = true;
+                            return `import ${quote}dayjs/plugin/${plugin}.js${quote}`;
+                        },
+                    );
+                }
+
+                // Only write if changes were made and content is different
+                if (hasChanges && modifiedContent !== originalContent) {
+                    try {
+                        await writeFile(filePath, modifiedContent, 'utf8');
+                        console.log(`🔧 Fixed dayjs imports in ${file}`);
+                        fixedFilesCount++;
+                    } catch (error) {
+                        errors.push({ file, error: error as Error });
+                        console.warn(`⚠️  Failed to write file ${file}:`, (error as Error).message);
+                    }
+                }
+            } catch (error) {
+                errors.push({ file, error: error as Error });
+                console.warn(`⚠️  Error processing file ${file}:`, (error as Error).message);
             }
+        }
+
+        // Summary reporting
+        if (processedFiles === 0) {
+            console.log('ℹ️  No JavaScript files found to process');
+            return 0;
+        }
+
+        if (errors.length > 0) {
+            console.warn(`⚠️  ${errors.length} file(s) had errors during processing`);
         }
 
         if (fixedFilesCount > 0) {
             console.log(`✅ Fixed dayjs imports in ${fixedFilesCount} file(s)`);
+        } else {
+            console.log('ℹ️  No dayjs imports found to fix');
         }
 
         return fixedFilesCount;
     } catch (error) {
-        console.error('❌ Error fixing dayjs imports:', error);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('❌ Critical error in fixDayjsImports:', errorMessage);
+
+        // Don't throw in production builds, just log and continue
+        if (process.env.NODE_ENV === 'production') {
+            console.warn('⚠️  Continuing build despite dayjs import fix errors');
+            return 0;
+        }
+
         throw error;
     }
 }

--- a/scripts/fix-dayjs-imports.ts
+++ b/scripts/fix-dayjs-imports.ts
@@ -1,0 +1,67 @@
+import { readdir, readFile, writeFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+/**
+ * Fix dayjs plugin imports in ESM files by adding .js extensions
+ * This addresses the ES module resolution issue where Node.js and bundlers
+ * require explicit file extensions for imports.
+ */
+export async function fixDayjsImports() {
+    try {
+        const distDir = resolve('dist');
+        const files = await readdir(distDir);
+
+        let fixedFilesCount = 0;
+
+        for (const file of files) {
+            // Only process .js files, skip source maps
+            if (!file.endsWith('.js') || file.endsWith('.map')) {
+                continue;
+            }
+
+            const filePath = join(distDir, file);
+
+            // Read file content once
+            const originalContent = await readFile(filePath, 'utf8');
+
+            // Create quote-agnostic regex patterns for both single and double quotes
+            const importPatterns = [
+                // from 'dayjs/plugin/timezone' or from "dayjs/plugin/timezone"
+                /from ['"](dayjs\/plugin\/(timezone|utc))['"]/g,
+                // import 'dayjs/plugin/timezone' or import "dayjs/plugin/timezone"
+                /import ['"](dayjs\/plugin\/(timezone|utc))['"]/g,
+            ];
+
+            // Apply all replacements
+            let modifiedContent = originalContent;
+            let hasChanges = false;
+
+            for (const pattern of importPatterns) {
+                const newContent = modifiedContent.replace(pattern, (match, pluginPath) => {
+                    hasChanges = true;
+                    return match.replace(pluginPath, `${pluginPath}.js`);
+                });
+
+                if (newContent !== modifiedContent) {
+                    modifiedContent = newContent;
+                }
+            }
+
+            // Only write if changes were made
+            if (hasChanges) {
+                await writeFile(filePath, modifiedContent, 'utf8');
+                console.log(`🔧 Fixed dayjs imports in ${file}`);
+                fixedFilesCount++;
+            }
+        }
+
+        if (fixedFilesCount > 0) {
+            console.log(`✅ Fixed dayjs imports in ${fixedFilesCount} file(s)`);
+        }
+
+        return fixedFilesCount;
+    } catch (error) {
+        console.error('❌ Error fixing dayjs imports:', error);
+        throw error;
+    }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,7 +14,7 @@ export function ignoreLogger(): void {}
  * @en Log data to console
  * @param data - Data to be logged
  */
-export function consoleLogger(data: unknown, symbol: keyof Console = 'log'): void {
+export function consoleLogger(data: unknown, symbol: keyof typeof console = 'log'): void {
     if (typeof console[symbol] === 'function') {
         (console[symbol] as (...data: unknown[]) => void)(data);
     }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-import path from 'path';
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => {
@@ -76,34 +74,17 @@ export default defineConfig((options) => {
         // Post-build success hook
         onSuccess: async () => {
             if (!options.watch) {
-                // Fix dayjs plugin imports in ESM files
-                const distDir = path.resolve('dist');
-                const files = fs.readdirSync(distDir);
+                try {
+                    // Import and run the dayjs import fixing helper
+                    const { fixDayjsImports } = await import('./scripts/fix-dayjs-imports.ts');
+                    await fixDayjsImports();
 
-                for (const file of files) {
-                    if (file.endsWith('.js') && !file.endsWith('.map')) {
-                        const filePath = path.join(distDir, file);
-                        let content = fs.readFileSync(filePath, 'utf8');
-
-                        // Replace dayjs plugin imports with .js extensions
-                        content = content.replace(
-                            /from 'dayjs\/plugin\/(timezone|utc)'/g,
-                            "from 'dayjs/plugin/$1.js'",
-                        );
-                        content = content.replace(
-                            /import 'dayjs\/plugin\/(timezone|utc)'/g,
-                            "import 'dayjs/plugin/$1.js'",
-                        );
-
-                        if (content !== fs.readFileSync(filePath, 'utf8')) {
-                            fs.writeFileSync(filePath, content);
-                            console.log(`🔧 Fixed dayjs imports in ${file}`);
-                        }
-                    }
+                    console.log('✅ Build completed successfully!');
+                } catch (error) {
+                    console.error('❌ Failed to fix dayjs imports:', error);
+                    // Don't fail the build, just warn
+                    console.log('⚠️  Build completed with warnings');
                 }
-
-                console.log('✅ Build completed successfully!');
-                console.log('📦 Package ready for publishing');
             }
         },
     };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => {
@@ -74,6 +76,32 @@ export default defineConfig((options) => {
         // Post-build success hook
         onSuccess: async () => {
             if (!options.watch) {
+                // Fix dayjs plugin imports in ESM files
+                const distDir = path.resolve('dist');
+                const files = fs.readdirSync(distDir);
+
+                for (const file of files) {
+                    if (file.endsWith('.js') && !file.endsWith('.map')) {
+                        const filePath = path.join(distDir, file);
+                        let content = fs.readFileSync(filePath, 'utf8');
+
+                        // Replace dayjs plugin imports with .js extensions
+                        content = content.replace(
+                            /from 'dayjs\/plugin\/(timezone|utc)'/g,
+                            "from 'dayjs/plugin/$1.js'",
+                        );
+                        content = content.replace(
+                            /import 'dayjs\/plugin\/(timezone|utc)'/g,
+                            "import 'dayjs/plugin/$1.js'",
+                        );
+
+                        if (content !== fs.readFileSync(filePath, 'utf8')) {
+                            fs.writeFileSync(filePath, content);
+                            console.log(`🔧 Fixed dayjs imports in ${file}`);
+                        }
+                    }
+                }
+
                 console.log('✅ Build completed successfully!');
                 console.log('📦 Package ready for publishing');
             }


### PR DESCRIPTION
## Pull Request Description
- Updated the type of the symbol parameter in consoleLogger function to use keyof typeof console for better type safety.
- Ensured compatibility with console methods while maintaining existing functionality.

## Type of Change

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## Related Issues or References
- Fixed #41

Please list any related issues or references here:

## Summary by Sourcery

Improve type safety of the consoleLogger function, patch ESM build outputs to correctly reference dayjs plugins, and bump the package version.

Bug Fixes:
- Correct the symbol parameter type in consoleLogger to keyof typeof console for stricter typing.

Enhancements:
- Add a post-build step in tsup to rewrite dayjs plugin imports with .js extensions in ESM files.

Build:
- Bump package version to 2.4.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Bumped package version to 2.4.3.
  - Build now runs a post-build fix that adjusts date-library imports to improve bundle compatibility and avoid runtime issues.

- **Refactor**
  - Tightened internal logging utility typing with no behavioral or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->